### PR TITLE
Skip virtual interfaces

### DIFF
--- a/scripts/update-motd.d/30-sysinfo
+++ b/scripts/update-motd.d/30-sysinfo
@@ -89,7 +89,7 @@ users=$(users | wc -w)
 swap_total=$(free -m | awk '/Swap/ { printf("%3.0f", $3/$2*100) }' | sed 's/ //g')
 swap_usage=${swap_usage//[!0-9]/} # to remove alfanumeric if swap not used
 swap_total=$(free -m |  awk '/Swap/ {print $(2)}')
-ip_address=$((ifconfig -a) | sed -n '/inet addr/s/.*addr.\([^ ]*\) .*/\1/p' | head -1)
+ip_address=$(for i in $(ls -l /sys/class/net/ | tail -n +2 | grep -v virtual | cut -d " " -f 9); do ifconfig $i; done | sed -n '/inet addr/s/.*addr.\([^ ]*\) .*/\1/p' | head -1)
 root_usage=$(df -h / | awk '/\// {print $(NF-1)}' | sed 's/%//g')
 root_total=$(df -h / | awk '/\// {print $(NF-4)}')
 if [ -e "$storage" ]; then


### PR DESCRIPTION
Don’t want ip address of virtual interfaces like docker0

I’m not totally sure about the head -1 thing though.  

What about machines with multiple physical interfaces with ip addresses?
